### PR TITLE
Updates to CI for Maven Central promotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.DS_Store
+.classpath
+.project
+.history
+.settings
 .idea/libraries
 .idea/tasks.xml
 .idea/workspace.xml

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -4,5 +4,7 @@ set -euo pipefail
 
 [[ -d $PWD/maven && ! -d $HOME/.m2 ]] && ln -s $PWD/maven $HOME/.m2
 
+REPOSITORY="${PWD}"/repository
+
 cd java-buildpack-security-provider
-./mvnw -q -Dmaven.test.skip=true deploy
+./mvnw -q -Dmaven.test.skip=true deploy -DcreateChecksum=true -DaltDeploymentRepository="local::default::file://${REPOSITORY}"

--- a/ci/promote-to-maven-central.sh
+++ b/ci/promote-to-maven-central.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export BUILD_INFO_LOCATION=$(pwd)/repository/build-info.json
+
+java -jar /concourse-release-scripts.jar publishToCentral 'RELEASE' "$BUILD_INFO_LOCATION" repository
+
+echo "Sync complete"

--- a/java-buildpack-container-security-provider.iml
+++ b/java-buildpack-container-security-provider.iml
@@ -64,7 +64,8 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.springframework:spring-jcl:5.2.5.RELEASE" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.springframework:spring-test:5.2.5.RELEASE" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.xmlunit:xmlunit-core:2.6.4" level="project" />
-    <orderEntry type="library" name="Maven: org.bouncycastle:bcpkix-jdk15on:1.65" level="project" />
-    <orderEntry type="library" name="Maven: org.bouncycastle:bcprov-jdk15on:1.65" level="project" />
+    <orderEntry type="library" name="Maven: org.bouncycastle:bcpkix-jdk15on:1.69" level="project" />
+    <orderEntry type="library" name="Maven: org.bouncycastle:bcprov-jdk15on:1.69" level="project" />
+    <orderEntry type="library" name="Maven: org.bouncycastle:bcutil-jdk15on:1.69" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,30 @@
     <groupId>org.cloudfoundry</groupId>
     <artifactId>java-buildpack-container-security-provider</artifactId>
     <name>Cloud Foundry Container Security Provider</name>
+    <description>Utility that watches for changes to container identity and trust stores</description>
     <version>1.20.0.BUILD-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/cloudfoundry/java-buildpack-container-security-provider</url>
+
+    <developers>
+        <developer>
+            <name>VMware</name>
+            <email>info@vmware.com</email>
+            <organization>VMware, Inc.</organization>
+            <organizationUrl>https://www.cloudfoundry.org</organizationUrl>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+    
+    <scm>
+        <url>https://github.com/cloudfoundry/java-buildpack-container-security-provider</url>
+    </scm>
 
     <properties>
         <bouncycastle.version>1.69</bouncycastle.version>
@@ -148,25 +169,22 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.jfrog.buildinfo</groupId>
-                <artifactId>artifactory-maven-plugin</artifactId>
-                <version>2.7.0</version>
-                <inherited>false</inherited>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <links>
+                        <link>https://projectreactor.io/docs/core/release/api/</link>
+                    </links>
+                    <quiet>true</quiet>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>build-info</id>
+                        <id>attach-javadocs</id>
                         <goals>
-                            <goal>publish</goal>
+                            <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <publisher>
-                                <contextUrl>https://repo.spring.io</contextUrl>
-                                <username>{{ARTIFACTORY_USERNAME}}</username>
-                                <password>{{ARTIFACTORY_PASSWORD}}</password>
-                                <repoKey>{{ARTIFACTORY_REPO_KEY|"libs-release-local"}}</repoKey>
-                                <snapshotRepoKey>{{ARTIFACTORY_SNAPSHOT_REPO_KEY|"libs-snapshot-local"}}</snapshotRepoKey>
-                            </publisher>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -178,9 +196,9 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>central</id>
-            <name>bintray-plugins</name>
-            <url>https://jcenter.bintray.com</url>
+            <id>jfrog-jars</id>
+            <name>jfrog-jars</name>
+            <url>https://oss.jfrog.org/artifactory/jfrog-jars/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
This PR adds requirements for Maven Central to the `pom.xml`, removes the GPG signing plugin (this is now performed in the CI), and adds a CI script to perform the promotion to Maven Central