### PR TITLE
Disables watching the private key file for updates

### DIFF
--- a/src/main/java/org/cloudfoundry/security/FileWatchingX509ExtendedKeyManager.java
+++ b/src/main/java/org/cloudfoundry/security/FileWatchingX509ExtendedKeyManager.java
@@ -55,7 +55,8 @@ final class FileWatchingX509ExtendedKeyManager extends X509ExtendedKeyManager {
         this.keyManagerFactory = keyManagerFactory;
 
         new FileWatcher(this.certificates, new FileWatcherCallback()).watch();
-        new FileWatcher(this.privateKey, new FileWatcherCallback()).watch();
+        // disable watching the key file to prevent race condition bug - a certificate file change covers the key change
+        // new FileWatcher(this.privateKey, new FileWatcherCallback()).watch();
 
         if (this.keyManager.compareAndSet(null, getKeyManager(getKeyStore()))) {
             this.logger.info(String.format("Initialized KeyManager for %s and %s", this.privateKey, this.certificates));


### PR DESCRIPTION
Previously, both the certificate and private key file were watched for changes and upon a change to either, both values were read and used to update the KeyManager. This caused an infrequent race-condition (see #8) where a mix of old and new data was left in the KeyManager until the next key/cert rotation. This resulted in apps that used client cert authentication to receive `bad_certificate` errors from the server side.

This PR disables the Filewatcher & callback for the private key file, as changes to the certificate file alone should indicate the presence of new key & cert values since the cert will be updated after the key. Both new values will therefore be updated to the KeyManager upon a cert file change.

Fixes #8 
Supersedes #10 & #9 
